### PR TITLE
Fixed RogueLikeMap syncing

### DIFF
--- a/TheSadRogue.Integration/TheSadRogue.Integration.csproj
+++ b/TheSadRogue.Integration/TheSadRogue.Integration.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+        <LangVersion>8.0</LangVersion>
         <Nullable>enable</Nullable>
-        <TargetFrameworks>net5.0;netcoreapp3.1;netstandard2.1</TargetFrameworks>
-        <LangVersion>9</LangVersion>
         <PackageVersion>0.0.0</PackageVersion>
-		
+
 		<!--
         Warnings disabled project-wide:
           - CA1043: GoRogue explicitly permits non-integral/string values to be used as indexers (Point for IMapView)


### PR DESCRIPTION
- Modified integration library to target C# 8 (last fully supported version for .NET Standard).  This will prevent accidentally using features that are unsupported in the .NET Standard/Core targets.
- Modified RoguelikeMap to use minimally required events to sync (fixes #27).