### PR TITLE
resync to parent (#15)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,187 @@
+# editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[project.json]
+indent_size = 2
+
+# C# files
+[*.cs]
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+
+# avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Types: use keywords instead of BCL types, and permit var only when the type is clear
+csharp_style_var_for_built_in_types = true:none
+csharp_style_var_when_type_is_apparent = true:none
+csharp_style_var_elsewhere = true:none
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds   = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# static fields should have s_ prefix
+dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_have_prefix.style    = static_prefix_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
+dotnet_naming_style.static_prefix_style.required_prefix = s_
+dotnet_naming_style.static_prefix_style.capitalization = camel_case 
+
+# internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case 
+
+# Code style defaults
+csharp_using_directive_placement = outside_namespace:suggestion
+dotnet_sort_system_directives_first = true
+csharp_prefer_braces = false:refactoring
+csharp_preserve_single_line_blocks = true:none
+csharp_preserve_single_line_statements = false:none
+csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_simple_using_statement = false:none
+csharp_style_prefer_switch_expression = true:suggestion
+
+# Resharper brace settings
+resharper_braces_redundant=true
+
+# Code quality
+dotnet_style_readonly_field = true:suggestion
+dotnet_code_quality_unused_parameters = non_public:suggestion
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:refactoring
+dotnet_style_prefer_conditional_expression_over_return = true:refactoring
+csharp_prefer_simple_default_expression = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = true:refactoring
+csharp_style_expression_bodied_constructors = true:refactoring
+csharp_style_expression_bodied_operators = true:refactoring
+csharp_style_expression_bodied_properties = true:refactoring
+csharp_style_expression_bodied_indexers = true:refactoring
+csharp_style_expression_bodied_accessors = true:refactoring
+csharp_style_expression_bodied_lambdas = true:refactoring
+csharp_style_expression_bodied_local_functions = true:refactoring
+
+# Pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# Null checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Other features
+csharp_style_prefer_index_operator = false:none
+csharp_style_prefer_range_operator = false:none
+csharp_style_pattern_local_over_anonymous_function = false:none
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Analyzers
+dotnet_code_quality.ca1802.api_surface = private, internal
+
+# C++ Files
+[*.{cpp,h,in}]
+curly_bracket_next_line = true
+indent_brace_style = Allman
+
+# Xml project files
+[*.{csproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
+indent_size = 2
+
+# Xml build files
+[*.builds]
+indent_size = 2
+
+# Xml files
+[*.{xml,stylecop,resx,ruleset}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+end_of_line = lf
+[*.{cmd, bat}]
+end_of_line = crlf

--- a/ExampleGame/Program.cs
+++ b/ExampleGame/Program.cs
@@ -21,7 +21,7 @@ namespace ExampleGame
         private const int MapHeight = 25;
         public static RogueLikeMap Map;
         public static RogueLikeEntity PlayerCharacter;
-        public static SettableCellSurface MapWindow;
+        //public static SettableCellSurface MapWindow;
         static void Main(/*string[] args*/)
         {
             Game.Create(Width, Height);
@@ -36,27 +36,27 @@ namespace ExampleGame
         private static void Init()
         {
             Map = GenerateMap();
-            var cells = new ArrayView<ColoredGlyph>(MapWidth, MapHeight);
-            cells.ApplyOverlay(Map.TerrainView);
+            //var cells = new ArrayView<ColoredGlyph?>(MapWidth, MapHeight);
+            //cells.ApplyOverlay(Map.TerrainView);
 
-            MapWindow = new SettableCellSurface(Map, Width, Height);
+            //MapWindow = new SettableCellSurface(Map, Width, Height);
             // MapWindow.SadComponents.Add(Map.EntityRenderer);
-            
+
             PlayerCharacter = GeneratePlayerCharacter();
             Map.AddEntity(PlayerCharacter);
             GameHost.Instance.Screen = Map.CreateRenderer();
         }
-        
+
         private static RogueLikeMap GenerateMap()
         {
             var generator = new Generator(MapWidth, MapHeight)
                 .AddStep(new CompositeGenerationStep(MapWidth, MapHeight))
                 .Generate();
-            
+
             var generatedMap = generator.Context.GetFirst<ISettableGridView<bool>>();
 
             RogueLikeMap map = new RogueLikeMap(MapWidth, MapHeight, 4, Distance.Euclidean);
-            
+
             foreach(var location in map.Positions())
             {
                 bool walkable = generatedMap[location];
@@ -70,7 +70,7 @@ namespace ExampleGame
         private static RogueLikeEntity GeneratePlayerCharacter()
         {
             var position = Map.WalkabilityView.Positions().First(p => Map.WalkabilityView[p]);
-            var player = new RogueLikeEntity(position, 1, false, true, 1);
+            var player = new RogueLikeEntity(position, 1, false);
 
             var motionControl = new PlayerControlsComponent();
             player.AllComponents.Add(motionControl);

--- a/TheSadRogue.Integration.Tests/Components/ComponentBaseTests.cs
+++ b/TheSadRogue.Integration.Tests/Components/ComponentBaseTests.cs
@@ -1,6 +1,3 @@
-using System;
-using SadConsole;
-using SadConsole.Input;
 using SadRogue.Primitives;
 using TheSadRogue.Integration.Components;
 using Xunit;
@@ -26,7 +23,7 @@ namespace TheSadRogue.Integration.Tests.Components
 
     public class TestComponent : RogueLikeComponentBase
     {
-        public TestComponent() : base(true, true, true, true, 5)
+        public TestComponent() : base(true, true, true, true)
         {
         }
     }

--- a/TheSadRogue.Integration.Tests/Components/PlayerControlsTest.cs
+++ b/TheSadRogue.Integration.Tests/Components/PlayerControlsTest.cs
@@ -1,4 +1,3 @@
-using SadConsole;
 using SadRogue.Primitives;
 using TheSadRogue.Integration.Components;
 using Xunit;
@@ -10,7 +9,7 @@ namespace TheSadRogue.Integration.Tests.Components
         [Fact]
         public void NewPlayerControlsComponent()
         {
-            var player = new TheSadRogue.Integration.RogueLikeEntity((0,0), Color.White,1);
+            var player = new RogueLikeEntity((0,0), Color.White,1);
             var component = new PlayerControlsComponent();
             
             Assert.Equal(4, component.Motions.Count);

--- a/TheSadRogue.Integration.Tests/RogueLikeEntityTests.cs
+++ b/TheSadRogue.Integration.Tests/RogueLikeEntityTests.cs
@@ -1,4 +1,3 @@
-using SadConsole;
 using SadRogue.Primitives;
 using TheSadRogue.Integration.Components;
 using Xunit;

--- a/TheSadRogue.Integration.Tests/RogueLikeMapTests.cs
+++ b/TheSadRogue.Integration.Tests/RogueLikeMapTests.cs
@@ -1,4 +1,3 @@
-using SadConsole;
 using SadRogue.Primitives;
 using Xunit;
 

--- a/TheSadRogue.Integration/RogueLikeCell.cs
+++ b/TheSadRogue.Integration/RogueLikeCell.cs
@@ -18,7 +18,7 @@ namespace TheSadRogue.Integration
         /// <summary>
         /// The ColoredGlyph of this cell
         /// </summary>
-        public ColoredGlyph? Appearance { get; }
+        public ColoredGlyph Appearance { get; }
         
         /// <summary>
         /// Fired when the Appearance is changed.
@@ -54,11 +54,11 @@ namespace TheSadRogue.Integration
         /// <param name="transparent">Whether the Cell is considered in Field-of-View algorithms</param>
         /// <param name="idGenerator">The function which produces the unique ID for this Cell</param>
         /// <param name="customComponentContainer">Accepts a custom collection</param>
-        public RogueLikeCell(Point position, ColoredGlyph glyph, int layer, bool walkable = true, bool transparent = true, 
+        public RogueLikeCell(Point position, ColoredGlyph appearance, int layer, bool walkable = true, bool transparent = true, 
             Func<uint>? idGenerator = null, ITaggableComponentCollection? customComponentContainer = null) 
             : base(position, layer, walkable, transparent, idGenerator, customComponentContainer)
         {
-            Appearance = glyph;
+            Appearance = appearance;
         }
 
         /// <summary>

--- a/TheSadRogue.Integration/RogueLikeEntity.cs
+++ b/TheSadRogue.Integration/RogueLikeEntity.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using GoRogue.Components;
 using GoRogue.GameFramework;
 using GoRogue.GameFramework.Components;
@@ -20,7 +18,7 @@ namespace TheSadRogue.Integration
         public int Layer => ZIndex;
         public Map? CurrentMap { get; private set; }
         public ITaggableComponentCollection GoRogueComponents { get; private set; }
-        
+
         /// <summary>
         /// Each and every component on this entity
         /// </summary>
@@ -42,8 +40,8 @@ namespace TheSadRogue.Integration
         {
             get => _isTransparent;
             set => this.SafelySetProperty(ref _isTransparent, value, TransparencyChanged);
-        }        
-        
+        }
+
         /// <inheritdoc />
         public bool IsWalkable
         {
@@ -52,36 +50,38 @@ namespace TheSadRogue.Integration
         }
 
         #region initialization
-        public RogueLikeEntity(Point position, int glyph, bool walkable = true, bool transparent = true, int layer = 1) 
+        public RogueLikeEntity(Point position, int glyph, bool walkable = true, bool transparent = true, int layer = 1)
             : this(position, Color.White, Color.Black, glyph, walkable, transparent, layer)
         { }
 
-        public RogueLikeEntity(Point position, Color foreground, int glyph, bool walkable = true, bool transparent = true, int layer = 1) 
+        public RogueLikeEntity(Point position, Color foreground, int glyph, bool walkable = true, bool transparent = true, int layer = 1)
             : this(position, foreground, Color.Black, glyph, walkable, transparent, layer)
         { }
-        
-        public RogueLikeEntity(Point position, Color foreground, Color background, int glyph, bool walkable = true, bool transparent = true, int layer = 1) 
+
+        public RogueLikeEntity(Point position, Color foreground, Color background, int glyph, bool walkable = true, bool transparent = true, int layer = 1)
             : base(foreground, background, glyph, layer != 0 ? layer : throw new ArgumentException($"{nameof(RogueLikeEntity)} objects may not reside on the terrain layer.", nameof(layer)))
-        {            
+        {
             Position = position;
             PositionChanged += Position_Changed;
-            
+
             Appearance = new ColoredGlyph(foreground, background, glyph);
-            
+
             IsWalkable = walkable;
             IsTransparent = transparent;
-            
+
             GoRogueComponents = new ComponentCollection();
             AllComponents.ComponentAdded += On_GoRogueComponentAdded;
             AllComponents.ComponentRemoved += On_GoRogueComponentRemoved;
+
+            ID = GoRogue.Random.GlobalRandom.DefaultRNG.NextUInt();
         }
         #endregion
-        
+
         public void OnMapChanged(Map? newMap)
             => CurrentMap = newMap;
-        
+
         #region event handlers
-        
+
         public event EventHandler<GameObjectPropertyChanged<Point>>? Moved;
         public event EventHandler<GameObjectPropertyChanged<bool>>? TransparencyChanged;
         public event EventHandler<GameObjectPropertyChanged<bool>>? WalkabilityChanged;

--- a/TheSadRogue.Integration/RogueLikeMap.cs
+++ b/TheSadRogue.Integration/RogueLikeMap.cs
@@ -16,18 +16,20 @@ namespace TheSadRogue.Integration
     public class RogueLikeMap : Map
     {
         private readonly List<ScreenSurface> _renderers;
-        
+
         /// <summary>
         /// List of renderers (ScreenSurfaces) that currently render the map.
         /// </summary>
         public IReadOnlyList<ScreenSurface> Renderers => _renderers.AsReadOnly();
 
         /// <summary>
-        /// An IGridView of the ColoredGlyphs on the Terrain layer (0)
+        /// An IGridView of the ColoredGlyphs on the Terrain layer (0) that will produce a fully
+        /// transparent appearance if there is no terrain object at the requested location.
         /// </summary>
-        public IGridView<ColoredGlyph> TerrainView
-            => new LambdaTranslationGridView<IGameObject, ColoredGlyph>(Terrain, val => ((RogueLikeCell)val).Appearance);
+        public readonly IGridView<ColoredGlyph> TerrainView;
 
+        private static readonly ColoredGlyph _transparentAppearance =
+            new ColoredGlyph(Color.Transparent, Color.Transparent, 0, Mirror.None);
 
         /// <summary>
         /// Creates a new RogueLikeMap
@@ -40,17 +42,16 @@ namespace TheSadRogue.Integration
         /// <param name="layersBlockingTransparency">Layers which should factor into transparency</param>
         /// <param name="entityLayersSupportingMultipleItems">How many entity layers support multiple entities per layer</param>
         public RogueLikeMap(int width, int height, int numberOfEntityLayers, Distance distanceMeasurement,
-            uint layersBlockingWalkability = 4294967295, uint layersBlockingTransparency = 4294967295,
-            uint entityLayersSupportingMultipleItems = 0) : base(width, height, numberOfEntityLayers,
+            uint layersBlockingWalkability = uint.MaxValue, uint layersBlockingTransparency = uint.MaxValue,
+            uint entityLayersSupportingMultipleItems = uint.MaxValue) : base(width, height, numberOfEntityLayers,
             distanceMeasurement, layersBlockingWalkability, layersBlockingTransparency,
             entityLayersSupportingMultipleItems)
         {
-            Entities.ItemAdded += Entity_Added;
-            Entities.ItemMoved += Entity_Moved;
+            ObjectAdded += Object_Added;
+            ObjectRemoved += Object_Removed;
+
             _renderers = new List<ScreenSurface>();
-            
-            // EntityRenderer = new Renderer();
-            // EntityRenderer.DoEntityUpdate = true;
+            TerrainView = new LambdaTranslationGridView<IGameObject?, ColoredGlyph>(Terrain, GetTerrainAppearance);
         }
 
         /// <summary>
@@ -68,11 +69,11 @@ namespace TheSadRogue.Integration
 
             // Create surface representing the terrain layer of the map
             var cellSurface = new SettableCellSurface(this, viewWidth, viewHeight);
-            
+
             // Create screen surface that renders that cell surface and keep track of it
             var renderer = new ScreenSurface(cellSurface, font, fontSize);
             _renderers.Add(renderer);
-            
+
             // Create an EntityRenderer and configure it with all the appropriate entities,
             // then add it to the main surface
             var entityRenderer = new Renderer();
@@ -90,56 +91,58 @@ namespace TheSadRogue.Integration
         /// </summary>
         /// <param name="renderer">The renderer to unlink.</param>
         public void DisposeOfRenderer(ScreenSurface renderer) => _renderers.Remove(renderer);
-        
-        /// <summary>
-        /// Invoked when an entity is added via Map.AddEntity
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="eventArgs"></param>
-        private void Entity_Added(object? sender, ItemEventArgs<IGameObject> eventArgs)
+
+        private void Object_Added(object? sender, ItemEventArgs<IGameObject> e)
         {
-            switch (eventArgs.Item)
+            switch (e.Item)
             {
                 case RogueLikeCell terrain:
                     // Ensure we flag the surfaces of renderers as dirty on the add and on subsequent appearance changed events
                     terrain.AppearanceChanged += Terrain_AppearanceChanged;
                     Terrain_AppearanceChanged(terrain, EventArgs.Empty);
                     break;
-                
+
                 case RogueLikeEntity entity:
                     // Add to any entity renderers we have
                     foreach (var renderer in _renderers)
                         renderer.GetSadComponent<Renderer>()?.Add(entity);
-                    
+
                     break;
-                
+
                 default:
                     throw new InvalidOperationException(
                         $"Objects added to a {nameof(RogueLikeMap)} must be of type {nameof(RogueLikeCell)} for terrain, or {nameof(RogueLikeEntity)} for non-terrain");
             }
         }
 
-        /// <summary>
-        /// Invoked when an entity is added via Map.AddEntity
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="eventArgs"></param>
-        private void Entity_Moved(object? sender, ItemMovedEventArgs<IGameObject> eventArgs)
+        private void Object_Removed(object? sender, ItemEventArgs<IGameObject> e)
         {
-            if(eventArgs.Item is RogueLikeEntity rlEntity)
+            switch (e.Item)
             {
-                rlEntity.Position = eventArgs.NewPosition;
-                // rlEntity.Cell.Position = eventArgs.NewPosition;
-                foreach (var surface in _renderers)
-                    surface.IsDirty = true;
+                case RogueLikeCell terrain:
+                    // Ensure we flag the surfaces of renderers as dirty on the remove and unlike our changed handler
+                    terrain.AppearanceChanged -= Terrain_AppearanceChanged;
+                    Terrain_AppearanceChanged(terrain, EventArgs.Empty);
+                    break;
+
+                case RogueLikeEntity entity:
+                    // Remove from any entity renderers we have
+                    foreach (var renderer in _renderers)
+                    {
+                        var entityRenderer = renderer.GetSadComponent<Renderer>();
+                        entityRenderer?.Remove(entity);
+                    }
+                    break;
             }
         }
-        
+
         private void Terrain_AppearanceChanged(object? sender, EventArgs e)
         {
             foreach (var surface in _renderers)
                 surface.IsDirty = true;
-            
         }
+
+        private static ColoredGlyph GetTerrainAppearance(IGameObject? gameObject)
+            => ((RogueLikeCell?) gameObject)?.Appearance ?? _transparentAppearance;
     }
 }

--- a/TheSadRogue.Integration/SettableCellSurface.cs
+++ b/TheSadRogue.Integration/SettableCellSurface.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using GoRogue.GameFramework;
 using SadConsole;
 using SadConsole.Effects;
 using SadRogue.Primitives;
@@ -12,47 +11,47 @@ namespace TheSadRogue.Integration
     /// <summary>
     /// A CellSurface that renders the terrain layer of a map.
     /// </summary>
-    public class SettableCellSurface : GridViewBase<ColoredGlyph?>, ICellSurface
+    public class SettableCellSurface : GridViewBase<ColoredGlyph>, ICellSurface
     {
         private bool _isDirty = true;
         private readonly BoundedRectangle _viewArea;
         private Color _defaultBackground;
         private Color _defaultForeground;
-        private Map _map;
-     
+        private RogueLikeMap _map;
+
         #region properties
         /// <inheritdoc />
         public override int Height => _viewArea.BoundingBox.Height;
-        
+
         /// <inheritdoc />
         public override int Width => _viewArea.BoundingBox.Width;
 
         /// <inheritdoc />
-        public override ColoredGlyph? this[Point pos] => _map.GetTerrainAt<RogueLikeCell>(pos)?.Appearance;
-        
+        public override ColoredGlyph this[Point pos] => _map.TerrainView[pos];
+
         /// <inheritdoc />
         public Rectangle Area => _viewArea.BoundingBox;
-        
+
         /// <inheritdoc />
         public int TimesShiftedDown { get; set; }
-        
+
         /// <inheritdoc />
         public int TimesShiftedRight { get; set; }
-        
+
         /// <inheritdoc />
         public int TimesShiftedLeft { get; set; }
-        
+
         /// <inheritdoc />
         public int TimesShiftedUp { get; set; }
-        
+
         /// <inheritdoc />
         public bool UsePrintProcessor { get; set; }
-                
+
         /// <inheritdoc />
         public EffectsManager Effects { get; }
-        
+
         /// <inheritdoc />
-        public Color DefaultBackground 
+        public Color DefaultBackground
         {
             get => _defaultForeground;
             set { _defaultForeground = value; IsDirty = true; }
@@ -63,10 +62,10 @@ namespace TheSadRogue.Integration
             get => _defaultBackground;
             set { _defaultBackground = value; IsDirty = true; }
         }
-        
+
         /// <inheritdoc />
         public int DefaultGlyph { get; set; }
-        
+
         /// <inheritdoc />
         public bool IsDirty
         {
@@ -80,12 +79,12 @@ namespace TheSadRogue.Integration
                 }
             }
         }
-        
+
         /// <inheritdoc />
         public bool IsScrollable => Height != _viewArea.Area.Height || Width != _viewArea.Area.Width;
-        
+
         /// <inheritdoc />
-        public Rectangle View 
+        public Rectangle View
         {
             get => _viewArea.Area;
             set
@@ -94,14 +93,14 @@ namespace TheSadRogue.Integration
                 IsDirty = true;
             }
         }
-        
+
         /// <inheritdoc />
         public int ViewHeight
         {
             get => _viewArea.Area.Height;
             set => _viewArea.SetArea(_viewArea.Area.WithHeight(value));
         }
-        
+
         /// <inheritdoc />
         public Point ViewPosition
         {
@@ -112,18 +111,18 @@ namespace TheSadRogue.Integration
                 IsDirty = true;
             }
         }
-        
+
         /// <inheritdoc />
         public int ViewWidth
         {
             get => _viewArea.Area.Width;
             set => _viewArea.SetArea(_viewArea.Area.WithWidth(value));
         }
-        
+
         /// <inheritdoc />
-        public event EventHandler IsDirtyChanged;
+        public event EventHandler? IsDirtyChanged;
         #endregion
-        
+
         /// <summary>
         /// Create a new SettableCellSurface
         /// </summary>
@@ -134,13 +133,16 @@ namespace TheSadRogue.Integration
         {
             _map = map;
             Effects = new EffectsManager(this);
-            
+
             _viewArea = new BoundedRectangle((0, 0, viewWidth, viewHeight),
                 (0, 0, map.Width, map.Height));
         }
-        
+
+        // Disabled nullability check because the issue is due to SadConsole not annotating nullability
         /// <inheritdoc />
-        public IEnumerator<ColoredGlyph> GetEnumerator()
+#pragma warning disable 8613
+        public IEnumerator<ColoredGlyph?> GetEnumerator()
+#pragma warning restore 8613
         {
             foreach (var pos in this.Positions())
                 yield return this[pos];

--- a/TheSadRogue.Integration/TheSadRogue.Integration.csproj
+++ b/TheSadRogue.Integration/TheSadRogue.Integration.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+        <LangVersion>8.0</LangVersion>
         <Nullable>enable</Nullable>
-        <TargetFrameworks>net5.0;netcoreapp3.1;netstandard2.1</TargetFrameworks>
-        <LangVersion>9</LangVersion>
         <PackageVersion>0.0.0</PackageVersion>
-		
+
 		<!--
         Warnings disabled project-wide:
           - CA1043: GoRogue explicitly permits non-integral/string values to be used as indexers (Point for IMapView)


### PR DESCRIPTION
* Modified unit tests to only compile for .NET 5.0 since unit test projects are typically single-target.  Ignored typical warnings in project configuration for integration library.

* Fixed all compiler warnings, implementing and ID value for RoguelikeEntity along the way.  Modified Map to have a single `TerrainView` instead of one created per access, and to not allow null `ColoredGlyphs` in its surfaces.  Added editor config to deal with code formatting guidelines.

* Modified integration library to target C# 8 (last fully supported version for .NET Standard).  Modified RoguelikeMap to use minimally required events to sync (fixes #27).

Co-authored-by: Chris3606 <cridley106@gmail.com>