### PR TITLE
Visual Desync Fixes

### DIFF
--- a/ExampleGame/Program.cs
+++ b/ExampleGame/Program.cs
@@ -5,7 +5,6 @@ using SadRogue.Primitives;
 using SadRogue.Primitives.GridViews;
 using TheSadRogue.Integration;
 using TheSadRogue.Integration.Components;
-using TheSadRogue.Integration.MapGenerationSteps;
 using TheSadRogue.Integration.Maps;
 
 #pragma warning disable 8618
@@ -19,11 +18,10 @@ namespace ExampleGame
     {
         public const int Width = 80;
         public const int Height = 25;
-        private const int MapWidth = 80;
-        private const int MapHeight = 25;
+        private const int MapWidth = 100;
+        private const int MapHeight = 60;
         public static RogueLikeMap Map;
         public static RogueLikeEntity PlayerCharacter;
-        //public static SettableCellSurface MapWindow;
         static void Main(/*string[] args*/)
         {
             Game.Create(Width, Height);
@@ -37,27 +35,30 @@ namespace ExampleGame
         /// </summary>
         private static void Init()
         {
+            // Generate map
             Map = GenerateMap();
-            //var cells = new ArrayView<ColoredGlyph?>(MapWidth, MapHeight);
-            //cells.ApplyOverlay(Map.TerrainView);
 
-            //MapWindow = new SettableCellSurface(Map, Width, Height);
-            // MapWindow.SadComponents.Add(Map.EntityRenderer);
-
+            // Generate player and add to map
             PlayerCharacter = GeneratePlayerCharacter();
             Map.AddEntity(PlayerCharacter);
+
+            // Center view on player
+            // TODO: Null override to work around a GoRogue bug.
+            Map.AllComponents!.Add(new SadConsole.Components.SurfaceComponentFollowTarget { Target = PlayerCharacter });
+
             GameHost.Instance.Screen = Map;
         }
 
         private static RogueLikeMap GenerateMap()
         {
+            // Generate a rectangular map for the sake of testing.
             var generator = new Generator(MapWidth, MapHeight)
-                .AddStep(new CompositeGenerationStep(MapWidth, MapHeight))
+                .AddSteps(DefaultAlgorithms.RectangleMapSteps())
                 .Generate();
 
-            var generatedMap = generator.Context.GetFirst<ISettableGridView<bool>>();
+            var generatedMap = generator.Context.GetFirst<ISettableGridView<bool>>("WallFloor");
 
-            RogueLikeMap map = new RogueLikeMap(MapWidth, MapHeight, 4, Distance.Euclidean);
+            RogueLikeMap map = new RogueLikeMap(MapWidth, MapHeight, 4, Distance.Euclidean, viewSize: (Width, Height));
 
             foreach(var location in map.Positions())
             {

--- a/TheSadRogue.Integration/MapTerrainCellSurface.cs
+++ b/TheSadRogue.Integration/MapTerrainCellSurface.cs
@@ -12,7 +12,7 @@ namespace TheSadRogue.Integration
     /// <summary>
     /// A CellSurface that renders the terrain layer of a map.
     /// </summary>
-    public class SettableCellSurface : GridViewBase<ColoredGlyph>, ICellSurface
+    public class MapTerrainCellSurface : GridViewBase<ColoredGlyph>, ICellSurface
     {
         private bool _isDirty = true;
         private readonly BoundedRectangle _viewArea;
@@ -20,7 +20,7 @@ namespace TheSadRogue.Integration
         private Color _defaultForeground;
         private readonly RogueLikeMapBase _map;
 
-        #region properties
+        #region Properties/Indexers
         /// <inheritdoc />
         public override int Height => _viewArea.BoundingBox.Height;
 
@@ -124,13 +124,14 @@ namespace TheSadRogue.Integration
         public event EventHandler? IsDirtyChanged;
         #endregion
 
+        #region Initialization
         /// <summary>
-        /// Create a new SettableCellSurface
+        /// Create a new MapTerrainCellSurface
         /// </summary>
         /// <param name="map">The map which we are rendering</param>
         /// <param name="viewWidth">The height of the view (screen size)</param>
         /// <param name="viewHeight">The Width of the view (screen size)</param>
-        public SettableCellSurface(RogueLikeMapBase map, int viewWidth, int viewHeight)
+        public MapTerrainCellSurface(RogueLikeMapBase map, int viewWidth, int viewHeight)
         {
             _map = map;
             Effects = new EffectsManager(this);
@@ -138,6 +139,7 @@ namespace TheSadRogue.Integration
             _viewArea = new BoundedRectangle((0, 0, viewWidth, viewHeight),
                 (0, 0, map.Width, map.Height));
         }
+        #endregion
 
         // Disabled nullability check because the issue is due to SadConsole not annotating nullability
         /// <inheritdoc />

--- a/TheSadRogue.Integration/Maps/RogueLikeMapBase.cs
+++ b/TheSadRogue.Integration/Maps/RogueLikeMapBase.cs
@@ -126,7 +126,7 @@ namespace TheSadRogue.Integration.Maps
                 case RogueLikeCell terrain:
                     // Ensure we flag the surfaces of renderers as dirty on the add and on subsequent isDirty events
                     terrain.Appearance.IsDirtySet += Terrain_AppearanceIsDirtySet;
-                    Terrain_AppearanceIsDirtySet(terrain, EventArgs.Empty);
+                    Terrain_AppearanceIsDirtySet(terrain.Appearance, EventArgs.Empty);
                     break;
 
                 case RogueLikeEntity entity:
@@ -149,7 +149,7 @@ namespace TheSadRogue.Integration.Maps
                 case RogueLikeCell terrain:
                     // Ensure we flag the surfaces of renderers as dirty on the remove and unlike our changed handler
                     terrain.Appearance.IsDirtySet -= Terrain_AppearanceIsDirtySet;
-                    Terrain_AppearanceIsDirtySet(terrain, EventArgs.Empty);
+                    Terrain_AppearanceIsDirtySet(terrain.Appearance, EventArgs.Empty);
                     break;
 
                 case RogueLikeEntity entity:

--- a/TheSadRogue.Integration/Maps/RogueLikeMapBase.cs
+++ b/TheSadRogue.Integration/Maps/RogueLikeMapBase.cs
@@ -90,7 +90,7 @@ namespace TheSadRogue.Integration.Maps
             var (viewWidth, viewHeight) = viewSize ?? (Width, Height);
 
             // Create surface representing the terrain layer of the map
-            var cellSurface = new SettableCellSurface(this, viewWidth, viewHeight);
+            var cellSurface = new MapTerrainCellSurface(this, viewWidth, viewHeight);
 
             // Create screen surface that renders that cell surface and keep track of it
             var renderer = new ScreenSurface(cellSurface, font, fontSize);

--- a/TheSadRogue.Integration/Maps/RogueLikeMapBase.cs
+++ b/TheSadRogue.Integration/Maps/RogueLikeMapBase.cs
@@ -124,9 +124,9 @@ namespace TheSadRogue.Integration.Maps
             switch (e.Item)
             {
                 case RogueLikeCell terrain:
-                    // Ensure we flag the surfaces of renderers as dirty on the add and on subsequent appearance changed events
-                    terrain.AppearanceChanged += Terrain_AppearanceChanged;
-                    Terrain_AppearanceChanged(terrain, EventArgs.Empty);
+                    // Ensure we flag the surfaces of renderers as dirty on the add and on subsequent isDirty events
+                    terrain.Appearance.IsDirtySet += Terrain_AppearanceIsDirtySet;
+                    Terrain_AppearanceIsDirtySet(terrain, EventArgs.Empty);
                     break;
 
                 case RogueLikeEntity entity:
@@ -148,8 +148,8 @@ namespace TheSadRogue.Integration.Maps
             {
                 case RogueLikeCell terrain:
                     // Ensure we flag the surfaces of renderers as dirty on the remove and unlike our changed handler
-                    terrain.AppearanceChanged -= Terrain_AppearanceChanged;
-                    Terrain_AppearanceChanged(terrain, EventArgs.Empty);
+                    terrain.Appearance.IsDirtySet -= Terrain_AppearanceIsDirtySet;
+                    Terrain_AppearanceIsDirtySet(terrain, EventArgs.Empty);
                     break;
 
                 case RogueLikeEntity entity:
@@ -172,7 +172,7 @@ namespace TheSadRogue.Integration.Maps
                 SadComponents.Remove(sadComponent);
         }
 
-        private void Terrain_AppearanceChanged(object? sender, EventArgs e)
+        private void Terrain_AppearanceIsDirtySet(object? sender, EventArgs e)
         {
             foreach (var surface in _renderers)
                 surface.IsDirty = true;

--- a/TheSadRogue.Integration/RogueLikeCell.cs
+++ b/TheSadRogue.Integration/RogueLikeCell.cs
@@ -19,12 +19,7 @@ namespace TheSadRogue.Integration
         /// The ColoredGlyph of this cell
         /// </summary>
         public ColoredGlyph Appearance { get; }
-        
-        /// <summary>
-        /// Fired when the Appearance is changed.
-        /// </summary>
-        public event EventHandler? AppearanceChanged;
-        
+
         /// <summary>
         /// Creates a new RogueLikeCell
         /// </summary>
@@ -37,9 +32,9 @@ namespace TheSadRogue.Integration
         /// <param name="transparent">Whether the Cell is considered in Field-of-View algorithms</param>
         /// <param name="idGenerator">The function which produces the unique ID for this Cell</param>
         /// <param name="customComponentContainer">Accepts a custom collection</param>
-        public RogueLikeCell(Point position, Color foreground, Color background, int glyph, int layer, 
-            bool walkable = true, bool transparent = true, Func<uint>? idGenerator = null, 
-            ITaggableComponentCollection? customComponentContainer = null) 
+        public RogueLikeCell(Point position, Color foreground, Color background, int glyph, int layer,
+            bool walkable = true, bool transparent = true, Func<uint>? idGenerator = null,
+            ITaggableComponentCollection? customComponentContainer = null)
             : base(position, layer, walkable, transparent, idGenerator, customComponentContainer)
         {
             Appearance = new ColoredGlyph(foreground, background, glyph);
@@ -54,50 +49,11 @@ namespace TheSadRogue.Integration
         /// <param name="transparent">Whether the Cell is considered in Field-of-View algorithms</param>
         /// <param name="idGenerator">The function which produces the unique ID for this Cell</param>
         /// <param name="customComponentContainer">Accepts a custom collection</param>
-        public RogueLikeCell(Point position, ColoredGlyph appearance, int layer, bool walkable = true, bool transparent = true, 
-            Func<uint>? idGenerator = null, ITaggableComponentCollection? customComponentContainer = null) 
+        public RogueLikeCell(Point position, ColoredGlyph appearance, int layer, bool walkable = true, bool transparent = true,
+            Func<uint>? idGenerator = null, ITaggableComponentCollection? customComponentContainer = null)
             : base(position, layer, walkable, transparent, idGenerator, customComponentContainer)
         {
             Appearance = appearance;
-        }
-
-        /// <summary>
-        /// Sets the glyph of the appearance of the object.
-        /// </summary>
-        /// <param name="glyph"/>
-        public void SetGlyph(int glyph)
-        {
-            if (Appearance.Glyph != glyph)
-            {
-                Appearance.Glyph = glyph;
-                AppearanceChanged?.Invoke(this, EventArgs.Empty);
-            }
-        }
-
-        /// <summary>
-        /// Sets the foreground color of the glyph for the object.
-        /// </summary>
-        /// <param name="foreground"/>
-        public void SetForeground(Color foreground)
-        {
-            if (Appearance.Foreground != foreground)
-            {
-                Appearance.Foreground = foreground;
-                AppearanceChanged?.Invoke(this, EventArgs.Empty);
-            }
-        }
-
-        /// <summary>
-        /// Sets the foreground color of the glyph for the object.
-        /// </summary>
-        /// <param name="background"/>
-        public void SetBackground(Color background)
-        {
-            if (Appearance.Background != background)
-            {
-                Appearance.Background = background;
-                AppearanceChanged?.Invoke(this, EventArgs.Empty);
-            }
         }
     }
 }


### PR DESCRIPTION
# Library Changes
- Fixes #21 by utilizing the new `IsDirtySet` event in `SadConsole.ColoredGlyph`
- Removed `AppearanceChanged` event from `RogueLikeCell` (replaced by `Appearance.IsDirtySet`)
- Removed `SetGlyph`, `SetBackground`, and `SetForegound` functions from `RogueLikeCell` (users can now set `Appearance` fields directly)
- Renamed terrain cell surface to something more indicative of its function.

# Miscellaneous
- Modified example to use a map bigger than the screen and to center the viewport on the player, so that viewports can be easily demonstrated.