### PR TITLE
Updated GoRogue

### DIFF
--- a/ExampleGame/ExampleGame.csproj
+++ b/ExampleGame/ExampleGame.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="GoRogue" Version="3.0.0-alpha01" />
+      <PackageReference Include="GoRogue" Version="3.0.0-alpha02" />
       <PackageReference Include="SadConsole.Host.SFML" Version="9.0.0-beta4" />
     </ItemGroup>
 

--- a/ExampleGame/Program.cs
+++ b/ExampleGame/Program.cs
@@ -7,7 +7,6 @@ using TheSadRogue.Integration;
 using TheSadRogue.Integration.Components;
 using TheSadRogue.Integration.Maps;
 
-#pragma warning disable 8618
 
 namespace ExampleGame
 {
@@ -20,8 +19,10 @@ namespace ExampleGame
         public const int Height = 25;
         private const int MapWidth = 100;
         private const int MapHeight = 60;
-        public static RogueLikeMap Map;
-        public static RogueLikeEntity PlayerCharacter;
+
+        // Initialized in Init, so null-override is used.
+        public static RogueLikeMap Map = null!;
+        public static RogueLikeEntity PlayerCharacter = null!;
         static void Main(/*string[] args*/)
         {
             Game.Create(Width, Height);
@@ -43,8 +44,7 @@ namespace ExampleGame
             Map.AddEntity(PlayerCharacter);
 
             // Center view on player
-            // TODO: Null override to work around a GoRogue bug.
-            Map.AllComponents!.Add(new SadConsole.Components.SurfaceComponentFollowTarget { Target = PlayerCharacter });
+            Map.AllComponents.Add(new SadConsole.Components.SurfaceComponentFollowTarget { Target = PlayerCharacter });
 
             GameHost.Instance.Screen = Map;
         }
@@ -53,8 +53,10 @@ namespace ExampleGame
         {
             // Generate a rectangular map for the sake of testing.
             var generator = new Generator(MapWidth, MapHeight)
-                .AddSteps(DefaultAlgorithms.RectangleMapSteps())
-                .Generate();
+                .ConfigAndGenerateSafe(gen =>
+                {
+                    gen.AddSteps(DefaultAlgorithms.RectangleMapSteps());
+                });
 
             var generatedMap = generator.Context.GetFirst<ISettableGridView<bool>>("WallFloor");
 

--- a/TheSadRogue.Integration/Maps/RogueLikeMapBase.cs
+++ b/TheSadRogue.Integration/Maps/RogueLikeMapBase.cs
@@ -36,7 +36,6 @@ namespace TheSadRogue.Integration.Maps
         private static readonly ColoredGlyph _transparentAppearance =
             new ColoredGlyph(Color.Transparent, Color.Transparent, 0, Mirror.None);
 
-        // TODO: This should be non-nullable but can't be due to a GoRogue bug
         /// <summary>
         /// Each and every component attached to the map.
         /// </summary>
@@ -44,7 +43,7 @@ namespace TheSadRogue.Integration.Maps
         /// Confused about which collection to add a component to?
         /// Add it here.
         /// </remarks>
-        public ITaggableComponentCollection? AllComponents => GoRogueComponents;
+        public ITaggableComponentCollection AllComponents => GoRogueComponents;
 
         /// <summary>
         /// Creates a new RogueLikeMapBase.
@@ -88,11 +87,9 @@ namespace TheSadRogue.Integration.Maps
             _surfaceEntityRenderers = new Dictionary<ScreenSurface, Renderer>();
             TerrainView = new LambdaTranslationGridView<IGameObject?, ColoredGlyph>(Terrain, GetTerrainAppearance);
 
-            if (AllComponents != null) // TODO: Workaround for GoRogue bug https://github.com/Chris3606/GoRogue/issues/219
-            {
-                AllComponents.ComponentAdded += On_GoRogueComponentAdded;
-                AllComponents.ComponentRemoved += On_GoRogueComponentRemoved;
-            }
+            AllComponents.ComponentAdded += On_GoRogueComponentAdded;
+            AllComponents.ComponentRemoved += On_GoRogueComponentRemoved;
+
         }
 
         /// <summary>

--- a/TheSadRogue.Integration/TheSadRogue.Integration.csproj
+++ b/TheSadRogue.Integration/TheSadRogue.Integration.csproj
@@ -33,7 +33,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="GoRogue" Version="3.0.0-alpha01" />
+      <PackageReference Include="GoRogue" Version="3.0.0-alpha02" />
       <PackageReference Include="SadConsole" Version="9.0.0-beta4" />
     </ItemGroup>
 


### PR DESCRIPTION
- Updated GoRogue to v3.0 alpha 2
- Removed workarounds for GoRogue bugs that were fixed in newest version
- Updated map gen usage in `ExampleGame` to fit new guidelines/functions implemented in most recent GoRogue update