### PR TITLE
Fix Mouse Processing and Non-Virtual Functions for Maps

### DIFF
--- a/TheSadRogue.Integration/Maps/RogueLikeMapBase.IScreenObject.cs
+++ b/TheSadRogue.Integration/Maps/RogueLikeMapBase.IScreenObject.cs
@@ -55,20 +55,7 @@ namespace SadRogue.Integration.Maps
         protected virtual bool ProcessMouse(MouseScreenObjectState state) => BackingObject.ProcessMouse(state);
 
         /// <inheritdoc/>
-        void IScreenObject.LostMouse(MouseScreenObjectState state)
-        {
-            // Transformation is required to ensure that backing objects which are surfaces are handled correctly.
-            // See https://github.com/thesadrogue/TheSadRogue.Integration/issues/47.
-            state = new MouseScreenObjectState(BackingObject, state.Mouse.Clone());
-            LostMouse(state);
-        }
-
-        /// <summary>
-        /// Overridable implementation of IScreenObject's LostMouse which is guaranteed to receive a mouse state
-        /// appropriate for the map implementation.
-        /// </summary>
-        /// <param name="state"/>
-        protected virtual void LostMouse(MouseScreenObjectState state) => BackingObject.LostMouse(state);
+        public virtual void LostMouse(MouseScreenObjectState state) => BackingObject.LostMouse(state);
 
         /// <summary>
         /// Calls Update for all entities, then Updates all SadComponents and Children. Only processes if IsEnabled is

--- a/TheSadRogue.Integration/Maps/RogueLikeMapBase.IScreenObject.cs
+++ b/TheSadRogue.Integration/Maps/RogueLikeMapBase.IScreenObject.cs
@@ -40,11 +40,8 @@ namespace SadRogue.Integration.Maps
         /// <inheritdoc/>
         bool IScreenObject.ProcessMouse(MouseScreenObjectState state)
         {
-            // The backing object may be an arbitrary IScreenObject which could be an IScreenSurface.  Because surfaces
-            // have positions and sizes, they are handled in a special way by mouse code (specifically the constructor
-            // of MouseScreenObjectState).  Therefore, if BackingObject is a surface we need to make sure this
-            // implementation invokes behavior appropriate for a surface.  So to ensure that any backing object will
-            // work appropriately, we'll just base the state off of the backing object itself.
+            // Transformation is required to ensure that backing objects which are surfaces are handled correctly.
+            // See https://github.com/thesadrogue/TheSadRogue.Integration/issues/47.
             state = new MouseScreenObjectState(BackingObject, state.Mouse.Clone());
             return ProcessMouse(state);
         }
@@ -60,11 +57,8 @@ namespace SadRogue.Integration.Maps
         /// <inheritdoc/>
         void IScreenObject.LostMouse(MouseScreenObjectState state)
         {
-            // The backing object may be an arbitrary IScreenObject which could be an IScreenSurface.  Because surfaces
-            // have positions and sizes, they are handled in a special way by mouse code (specifically the constructor
-            // of MouseScreenObjectState).  Therefore, if BackingObject is a surface we need to make sure this
-            // implementation invokes behavior appropriate for a surface.  So to ensure that any backing object will
-            // work appropriately, we'll just base the state off of the backing object itself.
+            // Transformation is required to ensure that backing objects which are surfaces are handled correctly.
+            // See https://github.com/thesadrogue/TheSadRogue.Integration/issues/47.
             state = new MouseScreenObjectState(BackingObject, state.Mouse.Clone());
             LostMouse(state);
         }


### PR DESCRIPTION
- Transformed mouse state as needed.  Fixes #47.
- Made appropriate functions of the map `IScreenObject` implementation virtual so a user can override them as intended