### PR TITLE
Fix Function Forwards

### DIFF
--- a/ExampleGame/Player.cs
+++ b/ExampleGame/Player.cs
@@ -24,9 +24,6 @@ namespace ExampleGame
             // Add component for controlling player movement via keyboard
             var motionControl = new PlayerControlsComponent();
             AllComponents.Add(motionControl);
-
-            // Ensure player receives input
-            IsFocused = true;
         }
 
         /// <summary>

--- a/ExampleGame/Program.cs
+++ b/ExampleGame/Program.cs
@@ -47,6 +47,7 @@ namespace ExampleGame
             Map.DefaultRenderer?.SadComponents.Add(new SadConsole.Components.SurfaceComponentFollowTarget { Target = PlayerCharacter });
 
             GameHost.Instance.Screen = Map;
+            Map.IsFocused = true;
         }
 
         private static RogueLikeMap GenerateMap()

--- a/ExampleGame/Program.cs
+++ b/ExampleGame/Program.cs
@@ -48,6 +48,7 @@ namespace ExampleGame
 
             GameHost.Instance.Screen = Map;
             Map.IsFocused = true;
+            GameHost.Instance.DestroyDefaultStartingConsole();
         }
 
         private static RogueLikeMap GenerateMap()

--- a/TheSadRogue.Integration/Maps/MapEntityForwarderComponent.cs
+++ b/TheSadRogue.Integration/Maps/MapEntityForwarderComponent.cs
@@ -68,8 +68,8 @@ namespace SadRogue.Integration.Maps
         {
             var map = (RogueLikeMap)host;
 
-            map!.Entities.ItemAdded -= EntitiesOnItemAdded;
-            map!.Entities.ItemRemoved -= EntitiesOnItemRemoved;
+            map.Entities.ItemAdded -= EntitiesOnItemAdded;
+            map.Entities.ItemRemoved -= EntitiesOnItemRemoved;
         }
 
         private void EntitiesOnItemAdded(object? sender, ItemEventArgs<IGameObject> e)

--- a/TheSadRogue.Integration/Maps/MapEntityForwarderComponent.cs
+++ b/TheSadRogue.Integration/Maps/MapEntityForwarderComponent.cs
@@ -61,6 +61,9 @@ namespace SadRogue.Integration.Maps
 
             map.Entities.ItemAdded += EntitiesOnItemAdded;
             map.Entities.ItemRemoved += EntitiesOnItemRemoved;
+
+            foreach (var entity in map.Entities.Items)
+                _mapEntities.Add((Entity)entity);
         }
 
         /// <inheritdoc />
@@ -70,6 +73,8 @@ namespace SadRogue.Integration.Maps
 
             map.Entities.ItemAdded -= EntitiesOnItemAdded;
             map.Entities.ItemRemoved -= EntitiesOnItemRemoved;
+
+            _mapEntities.Clear();
         }
 
         private void EntitiesOnItemAdded(object? sender, ItemEventArgs<IGameObject> e)

--- a/TheSadRogue.Integration/Maps/MapEntityForwarderComponent.cs
+++ b/TheSadRogue.Integration/Maps/MapEntityForwarderComponent.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using GoRogue.GameFramework;
+using GoRogue.SpatialMaps;
+using SadConsole;
+using SadConsole.Components;
+using SadConsole.Entities;
+using SadConsole.Input;
+
+namespace SadRogue.Integration.Maps
+{
+    /// <summary>
+    /// Component used by <see cref="RogueLikeMap"/> to process updates and keyboard/mouse events across its entities
+    /// as necessary.
+    /// </summary>
+    public class MapEntityForwarderComponent : IComponent
+    {
+        /// <inheritdoc />
+        public uint SortOrder { get; set; } = 0;
+
+        bool IComponent.IsUpdate => true;
+        bool IComponent.IsRender => false;
+        bool IComponent.IsMouse => true;
+        bool IComponent.IsKeyboard => true;
+
+        // Cached list of map entities for quick processing
+        private readonly List<Entity> _mapEntities = new List<Entity>();
+
+        /// <inheritdoc />
+        public void Update(IScreenObject host, TimeSpan delta)
+        {
+            foreach (var entity in _mapEntities.ToArray())
+                entity.Update(delta);
+        }
+
+        /// <inheritdoc />
+        public void Render(IScreenObject host, TimeSpan delta) { }
+
+        /// <inheritdoc />
+        public void ProcessMouse(IScreenObject host, MouseScreenObjectState state, out bool handled)
+        {
+            handled = false;
+            foreach (var entity in _mapEntities.ToArray())
+                handled = entity.ProcessMouse(state);
+        }
+
+        /// <inheritdoc />
+        public void ProcessKeyboard(IScreenObject host, Keyboard keyboard, out bool handled)
+        {
+            handled = false;
+            foreach (var entity in _mapEntities.ToArray())
+                handled = entity.ProcessKeyboard(keyboard);
+        }
+
+        /// <inheritdoc />
+        public void OnAdded(IScreenObject host)
+        {
+            if (!(host is RogueLikeMap map))
+                throw new InvalidOperationException(
+                    $"{nameof(MapEntityForwarderComponent)} components may only be attached to objects of type ${nameof(RogueLikeMap)}.");
+
+            map.Entities.ItemAdded += EntitiesOnItemAdded;
+            map.Entities.ItemRemoved += EntitiesOnItemRemoved;
+        }
+
+        /// <inheritdoc />
+        public void OnRemoved(IScreenObject host)
+        {
+            var map = (RogueLikeMap)host;
+
+            map!.Entities.ItemAdded -= EntitiesOnItemAdded;
+            map!.Entities.ItemRemoved -= EntitiesOnItemRemoved;
+        }
+
+        private void EntitiesOnItemAdded(object? sender, ItemEventArgs<IGameObject> e)
+        {
+            // Cast is guaranteed to succeed due to invariants enforced by RogueLikeMap
+            _mapEntities.Add((Entity)e.Item);
+        }
+
+        private void EntitiesOnItemRemoved(object? sender, ItemEventArgs<IGameObject> e)
+        {
+            // Cast is guaranteed to succeed due to invariants enforced by RogueLikeMap
+            _mapEntities.Remove((Entity)e.Item);
+        }
+    }
+}

--- a/TheSadRogue.Integration/Maps/RogueLikeMap.IScreenObject.cs
+++ b/TheSadRogue.Integration/Maps/RogueLikeMap.IScreenObject.cs
@@ -423,80 +423,11 @@ namespace SadRogue.Integration.Maps
             }
 
             void FilterAddItem(IComponent component)
-            {
-                if (component.IsRender)
-                {
-                    if (!ComponentsRender.Contains(component))
-                        ComponentsRender.Add(component);
-                }
+                => ScreenObject.Components_FilterAddItem(component, ComponentsRender, ComponentsUpdate, ComponentsKeyboard, ComponentsMouse, ComponentsEmpty);
 
-                if (component.IsUpdate)
-                {
-                    if (!ComponentsUpdate.Contains(component))
-                        ComponentsUpdate.Add(component);
-                }
-
-                if (component.IsKeyboard)
-                {
-                    if (!ComponentsKeyboard.Contains(component))
-                        ComponentsKeyboard.Add(component);
-                }
-
-                if (component.IsMouse)
-                {
-                    if (!ComponentsMouse.Contains(component))
-                        ComponentsMouse.Add(component);
-                }
-
-                if (!component.IsRender && !component.IsUpdate && !component.IsKeyboard && !component.IsMouse)
-                {
-                    if (!ComponentsEmpty.Contains(component))
-                        ComponentsEmpty.Add(component);
-                }
-
-                ComponentsRender.Sort(CompareComponent);
-                ComponentsUpdate.Sort(CompareComponent);
-                ComponentsKeyboard.Sort(CompareComponent);
-                ComponentsMouse.Sort(CompareComponent);
-            }
 
             void FilterRemoveItem(IComponent component)
-            {
-                if (component.IsRender)
-                {
-                    if (ComponentsRender.Contains(component))
-                        ComponentsRender.Remove(component);
-                }
-
-                if (component.IsUpdate)
-                {
-                    if (ComponentsUpdate.Contains(component))
-                        ComponentsUpdate.Remove(component);
-                }
-
-                if (component.IsKeyboard)
-                {
-                    if (ComponentsKeyboard.Contains(component))
-                        ComponentsKeyboard.Remove(component);
-                }
-
-                if (component.IsMouse)
-                {
-                    if (ComponentsMouse.Contains(component))
-                        ComponentsMouse.Remove(component);
-                }
-
-                if (!component.IsRender && !component.IsUpdate && !component.IsKeyboard && !component.IsMouse)
-                {
-                    if (!ComponentsEmpty.Contains(component))
-                        ComponentsEmpty.Remove(component);
-                }
-
-                ComponentsRender.Sort(CompareComponent);
-                ComponentsUpdate.Sort(CompareComponent);
-                ComponentsKeyboard.Sort(CompareComponent);
-                ComponentsMouse.Sort(CompareComponent);
-            }
+                => ScreenObject.Components_FilterRemoveItem(component, ComponentsRender, ComponentsUpdate, ComponentsKeyboard, ComponentsMouse, ComponentsEmpty);
         }
 
         /// <summary>

--- a/TheSadRogue.Integration/Maps/RogueLikeMap.IScreenObject.cs
+++ b/TheSadRogue.Integration/Maps/RogueLikeMap.IScreenObject.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Runtime.Serialization;
 using SadConsole;
 using SadConsole.Components;
-using SadConsole.Entities;
 using SadConsole.Input;
 using SadRogue.Primitives;
 
@@ -223,14 +222,6 @@ namespace SadRogue.Integration.Maps
         public virtual void Update(TimeSpan delta)
         {
             if (!IsEnabled) return;
-
-            // Update entities in map
-            foreach (var entity in Entities.Items)
-            {
-                // Guaranteed to succeed since all must be RoguelikeEntities
-                var scEntity = (Entity)entity;
-                scEntity.Update(delta);
-            }
 
             foreach (IComponent component in ComponentsUpdate.ToArray())
                 component.Update(this, delta);

--- a/TheSadRogue.Integration/Maps/RogueLikeMap.cs
+++ b/TheSadRogue.Integration/Maps/RogueLikeMap.cs
@@ -227,6 +227,9 @@ namespace SadRogue.Integration.Maps
             if (defaultRendererParams.HasValue)
                 DefaultRenderer = CreateRenderer(defaultRendererParams.Value.ViewSize, defaultRendererParams.Value.Font,
                     defaultRendererParams.Value.FontSize);
+
+            // Add component for managing entity's Update, ProcessKeyboard, and ProcessMouse functions
+            SadComponents.Add(new MapEntityForwarderComponent());
         }
 
         /// <summary>


### PR DESCRIPTION
- Modifies example game to have the `Map` object as SadConsole's focused object
    - Properly disposes of starting console
- Enables forwarding of ProcessMouse and ProcessKeyboard functions to entities on a map that is the active/focused screen
    - Allows entities to process keyboard/mouse events while the map is focused
- Moved responsibility for forwarding calls to a component