### PR TITLE
Fixed Setting Walkability of Map Objects

### DIFF
--- a/TheSadRogue.Integration/RoguelikeEntity.IGameObject.cs
+++ b/TheSadRogue.Integration/RoguelikeEntity.IGameObject.cs
@@ -43,14 +43,14 @@ namespace SadRogue.Integration
         public bool IsTransparent
         {
             get => _isTransparent;
-            set => this.SafelySetProperty(ref _isTransparent, value, TransparencyChanged);
+            set => this.SafelySetProperty(ref _isTransparent, value, TransparencyChanging, TransparencyChanged);
         }
 
         /// <inheritdoc />
         public bool IsWalkable
         {
             get => _isWalkable;
-            set => this.SafelySetProperty(ref _isWalkable, value, WalkabilityChanged);
+            set => this.SafelySetProperty(ref _isWalkable, value, WalkabilityChanging, WalkabilityChanged);
         }
 
         /// <inheritdoc />
@@ -61,7 +61,13 @@ namespace SadRogue.Integration
         public event EventHandler<GameObjectPropertyChanged<Point>>? Moved;
 
         /// <inheritdoc />
+        public event EventHandler<GameObjectPropertyChanged<bool>>? TransparencyChanging;
+
+        /// <inheritdoc />
         public event EventHandler<GameObjectPropertyChanged<bool>>? TransparencyChanged;
+
+        /// <inheritdoc />
+        public event EventHandler<GameObjectPropertyChanged<bool>>? WalkabilityChanging;
 
         /// <inheritdoc />
         public event EventHandler<GameObjectPropertyChanged<bool>>? WalkabilityChanged;

--- a/TheSadRogue.Integration/TheSadRogue.Integration.csproj
+++ b/TheSadRogue.Integration/TheSadRogue.Integration.csproj
@@ -16,7 +16,7 @@
     Set version and automatically add "-debug" to the version number for debug builds so that they can be published
     to NuGet seperately from the Release builds (to enable full SourceLink support)
     -->
-    <Version>1.0.0-alpha02</Version>
+    <Version>1.0.0-alpha03</Version>
     <Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 
     <!-- Generate documentation files for all configurations since Debug and Release are both published to NuGet. -->
@@ -27,7 +27,7 @@
 
     <!-- More nuget package settings-->
     <PackageId>TheSadRogue.Integration</PackageId>
-    <PackageReleaseNotes>Changelog at https://github.com/thesadrogue/TheSadRogue.Integration/blob/main/TheSadRogue.Integration/readme.md.</PackageReleaseNotes>
+    <PackageReleaseNotes>Changelog at https://github.com/thesadrogue/TheSadRogue.Integration/blob/main/TheSadRogue.Integration/changelog.md.</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/thesadrogue/TheSadRogue.Integration</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -71,7 +71,7 @@
 
   <!-- Dependencies -->
   <ItemGroup>
-    <PackageReference Include="GoRogue" Version="3.0.0-alpha07" />
+    <PackageReference Include="GoRogue" Version="3.0.0-alpha08" />
 	<PackageReference Include="JetBrains.Annotations" Version="2021.2.0">
 	  <PrivateAssets>all</PrivateAssets>
 	</PackageReference>

--- a/TheSadRogue.Integration/changelog.md
+++ b/TheSadRogue.Integration/changelog.md
@@ -7,6 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 None.
 
+## [1.0.0-alpha03] - 2021-10-17
+
+## Added
+- Added `WalkabilityChanging` event that fires directly _before_ walkability is set to map objects
+- Added `TransparencyChanging` event that fires directly _before_ transparancy is set to map objects
+
+## Changed
+- Updated minimum required version of GoRogue to 3.0.0-alpha08
+
+## Fixed
+- Fixed bug that prevented setting the `IsWalkable` field of map objects while they were part of the map
+
 ## [1.0.0-alpha02] - 2021-10-13
 
 ## Added


### PR DESCRIPTION
- Updated to GoRogue alpha 8.
- Updated RogueLikeEntity IGameObject implementation to ensure no problems when changing entity walkability.  
- Modified csproj for alpha 3 release.