### PR TITLE
Update Dependencies

### DIFF
--- a/ExampleGame/Program.cs
+++ b/ExampleGame/Program.cs
@@ -90,7 +90,7 @@ namespace ExampleGame
         {
             // Create a player and position them at the first square encountered that is walkable,
             // for the sake of testing.
-            var position = Map.WalkabilityView.Positions().First(p => Map.WalkabilityView[p]);
+            var position = Map.WalkabilityView.Positions().ToEnumerable().First(p => Map.WalkabilityView[p]);
             var player = new Player(position);
 
             return player;

--- a/TheSadRogue.Integration/TheSadRogue.Integration.csproj
+++ b/TheSadRogue.Integration/TheSadRogue.Integration.csproj
@@ -35,7 +35,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageTags>2d;console;development;game;games;library;rogue;roguelike;roguelikes;standard;sadrogue;thesadrogue</PackageTags>
+    <PackageTags>2d;console;development;game;games;library;rogue;roguelike;roguelikes;standard;sadrogue;thesadrogue;gorogue;sadconsole</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 
     <!--

--- a/TheSadRogue.Integration/TheSadRogue.Integration.csproj
+++ b/TheSadRogue.Integration/TheSadRogue.Integration.csproj
@@ -71,8 +71,8 @@
 
   <!-- Dependencies -->
   <ItemGroup>
-    <PackageReference Include="GoRogue" Version="3.0.0-alpha11" />
-	<PackageReference Include="JetBrains.Annotations" Version="2021.2.0">
+    <PackageReference Include="GoRogue" Version="3.0.0-beta01" />
+	<PackageReference Include="JetBrains.Annotations" Version="2022.1.0">
 	  <PrivateAssets>all</PrivateAssets>
 	</PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />

--- a/TheSadRogue.Integration/TheSadRogue.Integration.csproj
+++ b/TheSadRogue.Integration/TheSadRogue.Integration.csproj
@@ -16,7 +16,7 @@
     Set version and automatically add "-debug" to the version number for debug builds so that they can be published
     to NuGet seperately from the Release builds (to enable full SourceLink support)
     -->
-    <Version>1.0.0-alpha04</Version>
+    <Version>1.0.0-beta01</Version>
     <Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 
     <!-- Generate documentation files for all configurations since Debug and Release are both published to NuGet. -->

--- a/TheSadRogue.Integration/changelog.md
+++ b/TheSadRogue.Integration/changelog.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 None.
 
+## [1.0.0-beta01] - 2022-10-07
+- Updated primitives library minimum version to ensure performance improvements
+
 ## [1.0.0-alpha03] - 2021-10-17
 
 ## Added

--- a/nuget/push_templates.bat
+++ b/nuget/push_templates.bat
@@ -1,0 +1,1 @@
+nuget push TheSadRogue.Integration.Templates.%1.nupkg -Source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
- Updated minimum required version of GoRogue to `3.0.0-beta01` (implicitly updates primitives library to 1.4.1)
    - Modified code as necessary to account for minor breaking changes
- Updated internal dependencies
- Added "GoRogue" and "SadConsole" tags to package (closes #64 )