### PR TITLE
Update Templates for Beta04

### DIFF
--- a/ExampleGame/CustomKeybindingsComponent.cs
+++ b/ExampleGame/CustomKeybindingsComponent.cs
@@ -1,0 +1,16 @@
+﻿using GoRogue.GameFramework;
+using SadRogue.Integration;
+using SadRogue.Integration.Keybindings;
+using SadRogue.Primitives;
+
+namespace ExampleGame
+{
+    internal class CustomKeybindingsComponent : KeybindingsComponent<RogueLikeEntity>
+    {
+        protected override void MotionHandler(Direction direction)
+        {
+            if (Parent!.CanMoveIn(direction))
+                Parent!.Position += direction;
+        }
+    }
+}

--- a/ExampleGame/Player.cs
+++ b/ExampleGame/Player.cs
@@ -21,7 +21,7 @@ namespace ExampleGame
             PositionChanged += OnPositionChanged;
 
             // Add component for controlling player movement via keyboard
-            var motionControl = new KeybindingsComponent();
+            var motionControl = new CustomKeybindingsComponent();
             motionControl.SetMotions(KeybindingsComponent.ArrowMotions);
             AllComponents.Add(motionControl);
         }

--- a/TheSadRogue.Integration.Templates/TheSadRogue.Integration.Templates.csproj
+++ b/TheSadRogue.Integration.Templates/TheSadRogue.Integration.Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>1.2.0</PackageVersion>
+    <PackageVersion>1.3.0</PackageVersion>
     <PackageId>TheSadRogue.Integration.Templates</PackageId>
     <Title>GoRogue-SadConsole Game Templates</Title>
     <Authors>Chris3606;Thraka;fcheadle</Authors>

--- a/TheSadRogue.Integration.Templates/template_code/Integration.Project.MonoGame.CSharp/CustomKeybindingsComponent.cs
+++ b/TheSadRogue.Integration.Templates/template_code/Integration.Project.MonoGame.CSharp/CustomKeybindingsComponent.cs
@@ -1,18 +1,23 @@
 ﻿using GoRogue.GameFramework;
+using SadRogue.Integration;
 using SadRogue.Integration.Keybindings;
 using SadRogue.Primitives;
 
 namespace TheSadRogue.Integration.Templates.MonoGame
 {
     /// <summary>
-    /// Subclass of the integration library's keybindings component that moves enemies as appropriate when the player
+    /// Subclass of the integration library's keybindings component that handles player movement and moves enemies as appropriate when the player
     /// moves.
     /// </summary>
     /// <remarks>
+    /// CUSTOMIZATION: This component is meant to be attached directly to the player entity; if you want to attach it to a renderer, map, or other
+    /// surface instead, you'll need to edit the MotionHandler to reference the player directly instead of using the Parent property.  You may also
+    /// want to change the parent class type parameter to specify a different type for the parent.
+    /// 
     /// CUSTOMIZATION: Components can also be attached to maps, so the code for calling TakeTurn on all entities could
     /// be moved to a map component as well so that it is more re-usable by code that doesn't pertain to movement.
     /// </remarks>
-    internal class CustomKeybindingsComponent : PlayerKeybindingsComponent
+    internal class CustomKeybindingsComponent : KeybindingsComponent<RogueLikeEntity>
     {
         protected override void MotionHandler(Direction direction)
         {

--- a/TheSadRogue.Integration.Templates/template_code/Integration.Project.MonoGame.CSharp/MapObjectFactory.cs
+++ b/TheSadRogue.Integration.Templates/template_code/Integration.Project.MonoGame.CSharp/MapObjectFactory.cs
@@ -36,8 +36,8 @@ namespace TheSadRogue.Integration.Templates.MonoGame
             // Add component for controlling player movement via keyboard.  Other (non-movement) keybindings can be
             // added as well
             var motionControl = new CustomKeybindingsComponent();
-            motionControl.SetMotions(PlayerKeybindingsComponent.ArrowMotions);
-            motionControl.SetMotions(PlayerKeybindingsComponent.NumPadAllMotions);
+            motionControl.SetMotions(KeybindingsComponent.ArrowMotions);
+            motionControl.SetMotions(KeybindingsComponent.NumPadAllMotions);
             player.AllComponents.Add(motionControl);
 
             // Add component for updating map's player FOV as they move

--- a/TheSadRogue.Integration.Templates/template_code/Integration.Project.MonoGame.CSharp/TheSadRogue.Integration.Templates.MonoGame.csproj
+++ b/TheSadRogue.Integration.Templates/template_code/Integration.Project.MonoGame.CSharp/TheSadRogue.Integration.Templates.MonoGame.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="SadConsole.Host.MonoGame" Version="9.2.2" />
-    <PackageReference Include="TheSadRogue.Integration" Version="1.0.0-beta02" />
+    <PackageReference Include="TheSadRogue.Integration" Version="1.0.0-beta04" />
   </ItemGroup>
 
 </Project>

--- a/TheSadRogue.Integration.Templates/template_code/Integration.Project.SFML.CSharp/CustomKeybindingsComponent.cs
+++ b/TheSadRogue.Integration.Templates/template_code/Integration.Project.SFML.CSharp/CustomKeybindingsComponent.cs
@@ -1,18 +1,23 @@
 ﻿using GoRogue.GameFramework;
+using SadRogue.Integration;
 using SadRogue.Integration.Keybindings;
 using SadRogue.Primitives;
 
 namespace TheSadRogue.Integration.Templates.SFML
 {
     /// <summary>
-    /// Subclass of the integration library's keybindings component that moves enemies as appropriate when the player
+    /// Subclass of the integration library's keybindings component that handles player movement and moves enemies as appropriate when the player
     /// moves.
     /// </summary>
     /// <remarks>
+    /// CUSTOMIZATION: This component is meant to be attached directly to the player entity; if you want to attach it to a renderer, map, or other
+    /// surface instead, you'll need to edit the MotionHandler to reference the player directly instead of using the Parent property.  You may also
+    /// want to change the parent class type parameter to specify a different type for the parent.
+    /// 
     /// CUSTOMIZATION: Components can also be attached to maps, so the code for calling TakeTurn on all entities could
     /// be moved to a map component as well so that it is more re-usable by code that doesn't pertain to movement.
     /// </remarks>
-    internal class CustomKeybindingsComponent : PlayerKeybindingsComponent
+    internal class CustomKeybindingsComponent : KeybindingsComponent<RogueLikeEntity>
     {
         protected override void MotionHandler(Direction direction)
         {

--- a/TheSadRogue.Integration.Templates/template_code/Integration.Project.SFML.CSharp/MapObjectFactory.cs
+++ b/TheSadRogue.Integration.Templates/template_code/Integration.Project.SFML.CSharp/MapObjectFactory.cs
@@ -36,8 +36,8 @@ namespace TheSadRogue.Integration.Templates.SFML
             // Add component for controlling player movement via keyboard.  Other (non-movement) keybindings can be
             // added as well
             var motionControl = new CustomKeybindingsComponent();
-            motionControl.SetMotions(PlayerKeybindingsComponent.ArrowMotions);
-            motionControl.SetMotions(PlayerKeybindingsComponent.NumPadAllMotions);
+            motionControl.SetMotions(KeybindingsComponent.ArrowMotions);
+            motionControl.SetMotions(KeybindingsComponent.NumPadAllMotions);
             player.AllComponents.Add(motionControl);
 
             // Add component for updating map's player FOV as they move

--- a/TheSadRogue.Integration.Templates/template_code/Integration.Project.SFML.CSharp/TheSadRogue.Integration.Templates.SFML.csproj
+++ b/TheSadRogue.Integration.Templates/template_code/Integration.Project.SFML.CSharp/TheSadRogue.Integration.Templates.SFML.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="SadConsole.Host.SFML" Version="9.2.1" />
-    <PackageReference Include="TheSadRogue.Integration" Version="1.0.0-beta02" />
+    <PackageReference Include="TheSadRogue.Integration" Version="1.0.0-beta04" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Changes
- Updated templates to use the integration library beta04
    - Requires code modifications due to the new semantics of `KeybindingsComponent`
- Bumped template version number to 1.3.0 for release prep
- Updated `ExampleGame` since its keybindings component didn't work as it was written after the beta4 changes.