### PR TITLE
Support Gradient in FOV Handler

### DIFF
--- a/ExampleGame/ExampleGame.csproj
+++ b/ExampleGame/ExampleGame.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -16,8 +16,8 @@
 
   <ItemGroup>
       <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
-      <PackageReference Include="SadConsole.Host.MonoGame" Version="10.0.0" />
-      <PackageReference Include="SadConsole" Version="10.0.2" />
+      <PackageReference Include="SadConsole.Host.MonoGame" Version="10.5.0" />
+      <PackageReference Include="SadConsole" Version="10.5.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/TheSadRogue.Integration.Tests/FieldOfView/FieldOfViewTests.cs
+++ b/TheSadRogue.Integration.Tests/FieldOfView/FieldOfViewTests.cs
@@ -1,0 +1,108 @@
+﻿using System.Linq;
+using GoRogue.GameFramework;
+using SadConsole.Quick;
+using SadRogue.Integration.FieldOfView;
+using SadRogue.Integration.Maps;
+using SadRogue.Primitives;
+using SadRogue.Primitives.GridViews;
+using Xunit;
+
+namespace SadRogue.Integration.Tests.FieldOfView;
+
+class CountingFieldOfViewHandler : FieldOfViewHandlerBase
+{
+    public int TerrainSeen { get; private set; }
+    public int TerrainUnseen { get; private set; }
+
+    public int EntitySeen { get; private set; }
+    public int EntityUnseen { get; private set; }
+
+    public CountingFieldOfViewHandler(bool newlySeenIncludesAllSeen)
+        : base(newlySeenIncludesAllSeen: newlySeenIncludesAllSeen)
+    {
+    }
+
+    protected override void UpdateTerrainSeen(RogueLikeCell terrain)
+    {
+        TerrainSeen++;
+    }
+
+    protected override void UpdateTerrainUnseen(RogueLikeCell terrain)
+    {
+        TerrainUnseen++;
+    }
+
+    protected override void UpdateEntitySeen(RogueLikeEntity entity)
+    {
+        EntitySeen++;
+    }
+
+    protected override void UpdateEntityUnseen(RogueLikeEntity entity)
+    {
+        EntityUnseen++;
+    }
+
+    public void ResetCounters()
+    {
+        TerrainSeen = 0;
+        TerrainUnseen = 0;
+        EntitySeen = 0;
+        EntityUnseen = 0;
+    }
+}
+
+public class FieldOfViewTests : IClassFixture<SadConsoleFixture>
+{
+    private const int RADIUS = 5;
+
+    [Fact]
+    public void FieldOfViewOnlyNewInSeen()
+    {
+        var pos = new Point(15, 15);
+        var map = new RogueLikeMap(30, 30, null, 1, Distance.Manhattan);
+        map.ApplyTerrainOverlay(
+            new LambdaGridView<IGameObject>(map.Width, map.Height,
+                _ => new RogueLikeCell(Color.White, Color.Black, '.', 0)));
+
+        var fov = new CountingFieldOfViewHandler(false);
+        map.AllComponents.Add(fov);
+
+        map.PlayerFOV.Calculate(pos, RADIUS);
+
+        Assert.Equal(map.Positions().Count(p => map.PlayerFOV.BooleanResultView[p]), fov.TerrainSeen);
+
+        fov.ResetCounters();
+
+        map.PlayerFOV.Calculate(16, 15, RADIUS);
+
+        // Should be one vertical line on the right side new, and one old
+        Assert.Equal(RADIUS * 2 + 1, fov.TerrainSeen);
+        Assert.Equal(RADIUS * 2 + 1, fov.TerrainUnseen);
+    }
+
+    [Fact]
+    public void FieldOfViewAllInSeen()
+    {
+        var pos = new Point(15, 15);
+        var map = new RogueLikeMap(30, 30, null, 1, Distance.Manhattan);
+        map.ApplyTerrainOverlay(
+            new LambdaGridView<IGameObject>(map.Width, map.Height,
+                _ => new RogueLikeCell(Color.White, Color.Black, '.', 0)));
+
+        var fov = new CountingFieldOfViewHandler(true);
+        map.AllComponents.Add(fov);
+
+        map.PlayerFOV.Calculate(pos, RADIUS);
+
+        Assert.Equal(map.Positions().Count(p => map.PlayerFOV.BooleanResultView[p]), fov.TerrainSeen);
+
+        fov.ResetCounters();
+
+        map.PlayerFOV.Calculate(16, 15, RADIUS);
+
+        // Should be the entire FOV in seen, and one vertical line in old
+        Assert.Equal(map.Positions().Count(p => map.PlayerFOV.BooleanResultView[p]), fov.TerrainSeen);
+        Assert.Equal(RADIUS * 2 + 1, fov.TerrainUnseen);
+    }
+
+}

--- a/TheSadRogue.Integration.Tests/FieldOfView/FieldOfViewTests.cs
+++ b/TheSadRogue.Integration.Tests/FieldOfView/FieldOfViewTests.cs
@@ -1,59 +1,16 @@
 ﻿using System.Linq;
 using GoRogue.GameFramework;
-using SadConsole.Quick;
-using SadRogue.Integration.FieldOfView;
 using SadRogue.Integration.Maps;
+using SadRogue.Integration.Tests.Mocks;
 using SadRogue.Primitives;
 using SadRogue.Primitives.GridViews;
 using Xunit;
 
 namespace SadRogue.Integration.Tests.FieldOfView;
 
-class CountingFieldOfViewHandler : FieldOfViewHandlerBase
-{
-    public int TerrainSeen { get; private set; }
-    public int TerrainUnseen { get; private set; }
-
-    public int EntitySeen { get; private set; }
-    public int EntityUnseen { get; private set; }
-
-    public CountingFieldOfViewHandler(bool newlySeenIncludesAllSeen)
-        : base(newlySeenIncludesAllSeen: newlySeenIncludesAllSeen)
-    {
-    }
-
-    protected override void UpdateTerrainSeen(RogueLikeCell terrain)
-    {
-        TerrainSeen++;
-    }
-
-    protected override void UpdateTerrainUnseen(RogueLikeCell terrain)
-    {
-        TerrainUnseen++;
-    }
-
-    protected override void UpdateEntitySeen(RogueLikeEntity entity)
-    {
-        EntitySeen++;
-    }
-
-    protected override void UpdateEntityUnseen(RogueLikeEntity entity)
-    {
-        EntityUnseen++;
-    }
-
-    public void ResetCounters()
-    {
-        TerrainSeen = 0;
-        TerrainUnseen = 0;
-        EntitySeen = 0;
-        EntityUnseen = 0;
-    }
-}
-
 public class FieldOfViewTests : IClassFixture<SadConsoleFixture>
 {
-    private const int RADIUS = 5;
+    private const int Radius = 5;
 
     [Fact]
     public void FieldOfViewOnlyNewInSeen()
@@ -67,17 +24,17 @@ public class FieldOfViewTests : IClassFixture<SadConsoleFixture>
         var fov = new CountingFieldOfViewHandler(false);
         map.AllComponents.Add(fov);
 
-        map.PlayerFOV.Calculate(pos, RADIUS);
+        map.PlayerFOV.Calculate(pos, Radius);
 
         Assert.Equal(map.Positions().Count(p => map.PlayerFOV.BooleanResultView[p]), fov.TerrainSeen);
 
         fov.ResetCounters();
 
-        map.PlayerFOV.Calculate(16, 15, RADIUS);
+        map.PlayerFOV.Calculate(16, 15, Radius);
 
         // Should be one vertical line on the right side new, and one old
-        Assert.Equal(RADIUS * 2 + 1, fov.TerrainSeen);
-        Assert.Equal(RADIUS * 2 + 1, fov.TerrainUnseen);
+        Assert.Equal(Radius * 2 + 1, fov.TerrainSeen);
+        Assert.Equal(Radius * 2 + 1, fov.TerrainUnseen);
     }
 
     [Fact]
@@ -92,17 +49,17 @@ public class FieldOfViewTests : IClassFixture<SadConsoleFixture>
         var fov = new CountingFieldOfViewHandler(true);
         map.AllComponents.Add(fov);
 
-        map.PlayerFOV.Calculate(pos, RADIUS);
+        map.PlayerFOV.Calculate(pos, Radius);
 
         Assert.Equal(map.Positions().Count(p => map.PlayerFOV.BooleanResultView[p]), fov.TerrainSeen);
 
         fov.ResetCounters();
 
-        map.PlayerFOV.Calculate(16, 15, RADIUS);
+        map.PlayerFOV.Calculate(16, 15, Radius);
 
         // Should be the entire FOV in seen, and one vertical line in old
         Assert.Equal(map.Positions().Count(p => map.PlayerFOV.BooleanResultView[p]), fov.TerrainSeen);
-        Assert.Equal(RADIUS * 2 + 1, fov.TerrainUnseen);
+        Assert.Equal(Radius * 2 + 1, fov.TerrainUnseen);
     }
 
 }

--- a/TheSadRogue.Integration.Tests/Mocks/MockFOVHandlers.cs
+++ b/TheSadRogue.Integration.Tests/Mocks/MockFOVHandlers.cs
@@ -1,0 +1,65 @@
+﻿using SadRogue.Integration.FieldOfView;
+
+namespace SadRogue.Integration.Tests.Mocks;
+
+/// <summary>
+/// An FOV handler only useful for testing which simply counts the number of times its functions are called.
+/// </summary>
+class CountingFieldOfViewHandler : FieldOfViewHandlerBase
+{
+    /// <summary>
+    /// Number of times <see cref="UpdateTerrainSeen"/> was called.
+    /// </summary>
+    public int TerrainSeen { get; private set; }
+
+    /// <summary>
+    /// Number of times <see cref="UpdateTerrainUnseen"/> was called.
+    /// </summary>
+    public int TerrainUnseen { get; private set; }
+
+    /// <summary>
+    /// Number of times <see cref="UpdateEntitySeen"/> was called.
+    /// </summary>
+    public int EntitySeen { get; private set; }
+
+    /// <summary>
+    /// Number of times <see cref="UpdateEntityUnseen"/> was called.
+    /// </summary>
+    public int EntityUnseen { get; private set; }
+
+    public CountingFieldOfViewHandler(bool newlySeenIncludesAllSeen)
+        : base(newlySeenIncludesAllSeen: newlySeenIncludesAllSeen)
+    {
+    }
+
+    protected override void UpdateTerrainSeen(RogueLikeCell terrain)
+    {
+        TerrainSeen++;
+    }
+
+    protected override void UpdateTerrainUnseen(RogueLikeCell terrain)
+    {
+        TerrainUnseen++;
+    }
+
+    protected override void UpdateEntitySeen(RogueLikeEntity entity)
+    {
+        EntitySeen++;
+    }
+
+    protected override void UpdateEntityUnseen(RogueLikeEntity entity)
+    {
+        EntityUnseen++;
+    }
+
+    /// <summary>
+    /// Reset all the function counters to 0.
+    /// </summary>
+    public void ResetCounters()
+    {
+        TerrainSeen = 0;
+        TerrainUnseen = 0;
+        EntitySeen = 0;
+        EntityUnseen = 0;
+    }
+}

--- a/TheSadRogue.Integration.Tests/TheSadRogue.Integration.Tests.csproj
+++ b/TheSadRogue.Integration.Tests/TheSadRogue.Integration.Tests.csproj
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="2.1.9" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.assert" Version="2.4.2" />
         <PackageReference Include="xunit.core" Version="2.4.2" />

--- a/TheSadRogue.Integration.Tests/TheSadRogue.Integration.Tests.csproj
+++ b/TheSadRogue.Integration.Tests/TheSadRogue.Integration.Tests.csproj
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-        <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.assert" Version="2.4.2" />
         <PackageReference Include="xunit.core" Version="2.4.2" />

--- a/TheSadRogue.Integration/TheSadRogue.Integration.csproj
+++ b/TheSadRogue.Integration/TheSadRogue.Integration.csproj
@@ -71,10 +71,10 @@
 
   <!-- Dependencies -->
   <ItemGroup>
-    <PackageReference Include="GoRogue" Version="3.0.0-beta08" />
-	  <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="SadConsole" Version="10.0.2" />
+    <PackageReference Include="GoRogue" Version="3.0.0-beta09" />
+	  <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="SadConsole" Version="10.5.0" />
   </ItemGroup>
 
   <!-- When packing, copy the nuget files to the nuget output directory -->


### PR DESCRIPTION
Closes #75 

- Bumps dependency versions
- Added flag to cause FOV handler to treat all currently seen cells as newly seen, which supports use cases like modifying the cell's brightness based on their distance from the FOV center.