### PR TITLE
Dependency Management and Bumping Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,3 +363,7 @@ FodyWeavers.xsd
 
 # JetBrains folders
 .idea/
+
+# Key files and nuget archives
+nuget/archive/
+**/*.key

--- a/TheSadRogue.Integration.Templates/TheSadRogue.Integration.Templates.csproj
+++ b/TheSadRogue.Integration.Templates/TheSadRogue.Integration.Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>1.4.0</PackageVersion>
+    <PackageVersion>1.5.0</PackageVersion>
     <PackageId>TheSadRogue.Integration.Templates</PackageId>
     <Title>GoRogue-SadConsole Game Templates</Title>
     <Authors>Chris3606;Thraka;fcheadle</Authors>

--- a/TheSadRogue.Integration.Templates/template_code/Integration.Project.MonoGame.CSharp/TheSadRogue.Integration.Templates.MonoGame.csproj
+++ b/TheSadRogue.Integration.Templates/template_code/Integration.Project.MonoGame.CSharp/TheSadRogue.Integration.Templates.MonoGame.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -16,9 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
-    <PackageReference Include="SadConsole.Host.MonoGame" Version="10.0.0" />
-    <PackageReference Include="SadConsole" Version="10.0.2" />
-    <PackageReference Include="TheSadRogue.Integration" Version="1.0.0" />
+    <PackageReference Include="SadConsole.Host.MonoGame" Version="10.5.0" />
+    <PackageReference Include="TheSadRogue.Integration" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/TheSadRogue.Integration.Templates/template_code/Integration.Project.SFML.CSharp/TheSadRogue.Integration.Templates.SFML.csproj
+++ b/TheSadRogue.Integration.Templates/template_code/Integration.Project.SFML.CSharp/TheSadRogue.Integration.Templates.SFML.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -14,9 +14,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SadConsole.Host.SFML" Version="10.0.0" />
-    <PackageReference Include="SadConsole" Version="10.0.2" />
-    <PackageReference Include="TheSadRogue.Integration" Version="1.0.0" />
+    <!--Explicitly list version of CSFML to work around an issue with current SadConsole release, where the version
+    of CSFML links with warnings on .NET 8.-->
+    <PackageReference Include="CSFML" Version="2.6.1" />
+    <PackageReference Include="SadConsole.Host.SFML" Version="10.5.0" />
+    <PackageReference Include="TheSadRogue.Integration" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/TheSadRogue.Integration/TheSadRogue.Integration.csproj
+++ b/TheSadRogue.Integration/TheSadRogue.Integration.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <!-- Basic package information -->
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <Authors>Chris3606, fcheadle, Thraka</Authors>
     <Company>TheSadRogue</Company>
-    <Copyright>Copyright © 2023 Christopher Ridley (Chris3606), Forrest Cheadle (fcheadle), Steve De George JR (Thraka)</Copyright>
+    <Copyright>Copyright © 2025 Christopher Ridley (Chris3606), Forrest Cheadle (fcheadle), Steve De George JR (Thraka)</Copyright>
     <Description>An official integration library for using GoRogue and SadConsole together to create a roguelike.</Description>
 
     <!-- Target enable nullable reference types -->
@@ -15,7 +15,7 @@
     Set version and automatically add "-debug" to the version number for debug builds so that they can be published
     to NuGet seperately from the Release builds (to enable full SourceLink support)
     -->
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 
     <!-- Generate documentation files for all configurations since Debug and Release are both published to NuGet. -->
@@ -62,6 +62,8 @@
     -->
     <NoWarn>CA1043;CA1303;CA1814;CA1710;CA1305;CA1051;CA1307;CA2211;CA1062</NoWarn>
 
+    <!-- Since we explicitly support .NET 7.0 as one (of many) targets, suppress the warning about .NET 7 being at end of life. -->
+    <CheckEolTargetFramework Condition="$(TargetFramework.StartsWith('net7.0')) == true">false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <!-- Define trace constant for debug builds. -->

--- a/TheSadRogue.Integration/changelog.md
+++ b/TheSadRogue.Integration/changelog.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 None.
 
+## [1.1.0] - 2025-01-01
+
+### Added
+- Project now targets .net 8.0 and .net 9.0 natively
+### Changed
+- `FOVHandlerBase` now takes a flag that causes `TerrainSeen` and `EntitySeen` to be called on all visible cells
+    - This allows canonical support for things like an FOV gradient based on distance from center
+
 ## [1.0.0] - 2023-11-11
 - Updated to GoRogue 3.0.0-beta08 and SadConsole v10
 - Removed support for all platforms prior to .NET 6.0 (these versions are no longer supported by SadConsole)

--- a/nuget/build.ps1
+++ b/nuget/build.ps1
@@ -1,0 +1,87 @@
+# Configuration
+$scriptDir = $PSScriptRoot
+$rootDir = Join-Path $scriptDir ".."
+$archive = Join-Path $scriptDir archive
+$corePackage = "TheSadRogue.Integration"
+$dependentPackages = @("TheSadRogue.Integration.Templates")
+$nugetKeyPath = Join-Path $scriptDir "nuget.key"
+
+# Delete any NuGet packages not moved to archive
+Write-Output "Removing old nupkg files"
+Remove-Item "$scriptDir\*.nupkg","$scriptDir\*.snupkg" -Force
+
+# Make sure archive directory exists
+if(!(Test-Path $archive))
+{
+    New-Item -Path $archive -ItemType Directory -Force | Out-Null
+}
+
+# Build core package
+Write-Output "Building $corePackage Debug and Release"
+$output = Invoke-Expression "dotnet build $rootDir\$corePackage\$corePackage.csproj -c Debug --no-cache"; if ($LASTEXITCODE -ne 0) { Write-Error "Failed"; Write-Output $output; throw }
+$output = Invoke-Expression "dotnet build $rootDir\$corePackage\$corePackage.csproj -c Release --no-cache"; if ($LASTEXITCODE -ne 0) { Write-Error "Failed"; Write-Output $output; throw }
+
+# Find the version we're using
+$version = (Get-Content $rootDir\$corePackage\$corePackage.csproj | Select-String "<Version>(.*)<").Matches[0].Groups[1].Value
+$nugetKey = Get-Content $nugetKeyPath
+Write-Output "Target $coreProjectVersion version is $version"
+
+# Push packages to nuget
+Write-Output "Pushing $corePackage packages"
+$corePackages = Get-ChildItem "$corePackage.*.nupkg" | Select-Object -ExpandProperty Name
+
+foreach ($package in $corePackages) {
+    $output = Invoke-Expression "dotnet nuget push `"$package`" -s nuget.org -k $nugetKey --skip-duplicate"; if ($LASTEXITCODE -ne 0) { Write-Error "Failed"; Write-Output $output; throw }
+}
+
+Write-Output "Query NuGet for 10 minutes to find the new package"
+
+$timeout = New-TimeSpan -Minutes 10
+$timer = [Diagnostics.StopWatch]::StartNew()
+[Boolean]$foundPackage = $false
+
+# Loop searching for the new SadConsole package
+while ($timer.elapsed -lt $timeout){
+
+    $existingVersions = (Invoke-WebRequest "https://api-v2v3search-0.nuget.org/query?q=PackageId:$corePackage&prerelease=true").Content | ConvertFrom-Json
+
+    if ($existingVersions.totalHits -eq 0) {
+        throw "Unable to get any results from NuGet"
+    }
+
+    if ($null -eq ($existingVersions.data.versions | Where-Object version -eq $version)) {
+        Write-Output "Waiting 30 seconds to retry..."
+        Start-Sleep -Seconds 30
+		
+    }
+    else {
+        Write-Output "Found package. Waiting 1 extra minute to let things settle"
+        $foundPackage = $true
+        Start-Sleep -Seconds 60
+        break
+    }
+}
+
+# Found the core package, start building and pushing the other packages
+if ($foundPackage){
+
+    foreach ($project in $dependentPackages) {
+        # Build package
+        Write-Output "Building $project Debug and Release"
+        $output = Invoke-Expression "dotnet build $rootDir\$project\$project.csproj -c Debug -p:UseProjectReferences=false --no-cache"; if ($LASTEXITCODE -ne 0) { Write-Error "Failed"; Write-Output $output; throw }
+        $output = Invoke-Expression "dotnet build $rootDir\$project\$project.csproj -c Release -p:UseProjectReferences=false --no-cache"; if ($LASTEXITCODE -ne 0) { Write-Error "Failed"; Write-Output $output; throw }
+
+        # Push packages to nuget
+        Write-Output "Pushing $project packages"
+        $packages = Get-ChildItem "$project*.nupkg" | Select-Object -ExpandProperty Name
+
+        foreach ($package in $packages) {
+            $output = Invoke-Expression "dotnet nuget push `"$package`" -s nuget.org -k $nugetKey --skip-duplicate"; if ($LASTEXITCODE -ne 0) { Write-Error "Failed"; Write-Output $output; throw }
+        }
+    }
+
+    # Archive the packages
+    Move-Item "$scriptDir\*.nupkg","$scriptDir\*.snupkg" $archive -force
+} else {
+    Write-Error "$corePackage didn't appear on NuGet within 10 minutes."
+}

--- a/nuget/push.bat
+++ b/nuget/push.bat
@@ -1,2 +1,0 @@
-nuget push TheSadRogue.Integration.%1-debug.nupkg -Source https://api.nuget.org/v3/index.json
-nuget push TheSadRogue.Integration.%1.nupkg -Source https://api.nuget.org/v3/index.json

--- a/nuget/push_templates.bat
+++ b/nuget/push_templates.bat
@@ -1,1 +1,0 @@
-nuget push TheSadRogue.Integration.Templates.%1.nupkg -Source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
- Added new release script
- Bumped version numbers
- Modified integration library version targeted by templates
- Managed dependencies in templates to update to recent versions and work around current issues with SFML

Note that the change to the version of integration library targeted by templates means that the templates won't build until the new version of the templates is deployed, unless you manually build the package and deploy it to a local nuget feed/folder.